### PR TITLE
Support for newer versions of gnome terminal

### DIFF
--- a/gnome-terminal/argonaut-new-dconf.sh
+++ b/gnome-terminal/argonaut-new-dconf.sh
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+# Create a new profile using the argonaut theme for gnome terminal and make it the default.
+# For newer versions of gnome terminal using dconf.
+
+path=/org/gnome/terminal/legacy/profiles:
+uuid="$(uuidgen)"
+
+dconf load "$path/:$uuid/" <<'EOF'
+[/]
+visible-name='Argonaut'
+use-theme-colors=false
+use-theme-background=false
+foreground-color='#FFFFFAFFF499'
+background-color='#135515C822FB'
+bold-color='#9E9B9C2A9A3A'
+palette=['#22C022C022C0', '#FFFF00000F12', '#8C9DE1C30A8E', '#FFFFB9FF0000', '#00008E07F911', '#6CF6435DA687', '#0000D882EC2E', '#FFFFFFFFFFFF', '#445744574457', '#FFFF279A3FCD', '#ABD7E1C35B40', '#FFFFD2A34206', '#002292C3FFFF', '#9AE35FC9EC4D', '#6779FFFFF0E1', '#FFFFFFFFFFFF']
+EOF
+
+profileList="$(dconf read "$path/list" | tr -d ']'),'$uuid']"
+dconf write "$path/list" "$profileList"
+dconf write "$path/default" "'$uuid'"

--- a/gnome-terminal/argonaut-old-gconf.sh
+++ b/gnome-terminal/argonaut-old-gconf.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Load configuration for old versions of gnome terminal using gconf
+
 gconftool-2 -s -t string /apps/gnome-terminal/profiles/Default/palette "#22C022C022C0:#FFFF00000F12:#8C9DE1C30A8E:#FFFFB9FF0000:#00008E07F911:#6CF6435DA687:#0000D882EC2E:#FFFFFFFFFFFF:#445744574457:#FFFF279A3FCD:#ABD7E1C35B40:#FFFFD2A34206:#002292C3FFFF:#9AE35FC9EC4D:#6779FFFFF0E1:#FFFFFFFFFFFF"
 gconftool-2 -s -t string /apps/gnome-terminal/profiles/Default/background_color "#135515C822FB"
 gconftool-2 -s -t string /apps/gnome-terminal/profiles/Default/foreground_color "#FFFFFAFFF499"


### PR DESCRIPTION
Since years gnome terminal is using the newer dconf instead of the older gconf. This pull requests adds a new script that allows to apply the argonaut theme to newer versions of gnome terminal.